### PR TITLE
feat: add-page-loader and setup client authentication

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -27,6 +27,7 @@
         "react/jsx-filename-extension": "off",
         "react/jsx-props-no-spreading": "off",
         "prefer-destructuring": "off",
-        "import/no-unresolved": "off"
+        "import/no-unresolved": "off",
+        "array-callback-return": "off"
     }
 }

--- a/package.json
+++ b/package.json
@@ -55,11 +55,13 @@
     "@emotion/styled": "^10.0.27",
     "@types/react": "^16.9.35",
     "apollo-link-context": "^1.0.20",
+    "apollo-link-error": "^1.1.13",
     "date-fns": "^2.13.0",
     "emotion-theming": "^10.0.27",
     "graphql": "^15.0.0",
     "prop-types": "^15.7.2",
     "react": "^16.13.1",
+    "react-content-loader": "^5.0.4",
     "react-dom": "^16.13.1",
     "react-markdown": "^4.3.1",
     "react-router-dom": "^5.2.0"

--- a/src/components/Note/Note.js
+++ b/src/components/Note/Note.js
@@ -1,33 +1,65 @@
 import React from 'react';
-import { instanceOf } from 'prop-types';
+import { useLocation } from 'react-router-dom';
 import ReactMarkdown from 'react-markdown';
 import { format } from 'date-fns';
+import { Avatar, Box, Text } from '@chakra-ui/core';
+import { useQuery } from '@apollo/client';
 
-const Note = ({ note }) => {
-  const {
-    author: { avatar, username },
-    content,
-    createdAt,
-    favoriteCount,
-  } = note;
+import { NoteByIdQuery } from '../../graphql/queries/note';
+import { NotesLoader } from '../core/Loader';
+
+const Note = () => {
+  const { pathname } = useLocation();
+  const noteId = pathname.split('/')[2];
+  const { loading, error, data } = useQuery(NoteByIdQuery, {
+    variables: { id: noteId },
+  });
+
+  if (loading) return <NotesLoader />;
+  if (error) {
+    return (
+      <p style={{ textAlign: 'center' }}>
+        ...please provide a valid token or login.....
+      </p>
+    );
+  }
 
   return (
-    <article>
-      <img src={avatar} alt="{username}avatar" height="50px" width="50px" />
-      {' '}
-      {username}
-      {' '}
-      {format(new Date(createdAt), 'MMM dd yyyy')}
-      {' '}
-      {favoriteCount}
-      {' '}
-      <ReactMarkdown source={content} />
-    </article>
+    <Box
+      borderWidth="1px"
+      rounded="lg"
+      overflow="hidden"
+      mt={5}
+      mb={5}
+      padding={5}
+      borderColor="grey.200"
+      boxShadow="lg"
+    >
+      <Box
+        d="flex"
+        justifyContent="space-between"
+        dir="row"
+        alignItems="center"
+      >
+        <Box d="flex" alignItems="center">
+          <Avatar
+            size="sm"
+            name={data.note.author.username}
+            src={data.note.author.avatar}
+          />
+          <Text ml={2} color="grey" fontSize="sm">
+            {data.note.author.username}
+          </Text>
+        </Box>
+        <Text color="grey" fontSize="sm">
+          {format(new Date(data.note.createdAt), 'MMM dd yyyy')}
+        </Text>
+      </Box>
+      <Box mt={5}>
+        <ReactMarkdown source={data.note.content} />
+      </Box>
+    </Box>
   );
-};
-
-Note.propTypes = {
-  note: instanceOf(Object).isRequired,
 };
 
 export default Note;

--- a/src/components/Note/NoteFeed.js
+++ b/src/components/Note/NoteFeed.js
@@ -1,10 +1,12 @@
 import React from 'react';
 import { instanceOf } from 'prop-types';
 
-import Note from './Note';
+import SampleNote from './SampleNote';
 
 const NoteFeed = ({ notes }) => (
-  <div>{notes && notes.map((note) => <Note key={note.id} note={note} />)}</div>
+  <div>
+    {notes && notes.map((note) => <SampleNote key={note.id} note={note} />)}
+  </div>
 );
 
 NoteFeed.propTypes = {

--- a/src/components/Note/SampleNote.js
+++ b/src/components/Note/SampleNote.js
@@ -1,0 +1,57 @@
+import React from 'react';
+import { instanceOf } from 'prop-types';
+import ReactMarkdown from 'react-markdown';
+import { format } from 'date-fns';
+import { Avatar, Box, Text } from '@chakra-ui/core';
+import { Link } from 'react-router-dom';
+
+const Note = ({ note }) => {
+  const {
+    id,
+    author: { avatar, username },
+    content,
+    createdAt,
+  } = note;
+
+  return (
+    <Link to={`/note/${id}`}>
+      <Box
+        borderWidth="1px"
+        rounded="lg"
+        overflow="hidden"
+        mt={5}
+        mb={5}
+        padding={5}
+        borderColor="grey.200"
+        boxShadow="lg"
+        onClick={() => null}
+      >
+        <Box
+          d="flex"
+          justifyContent="space-between"
+          dir="row"
+          alignItems="center"
+        >
+          <Box d="flex" alignItems="center">
+            <Avatar size="sm" name={username} src={avatar} />
+            <Text ml={2} color="grey" fontSize="sm">
+              {username}
+            </Text>
+          </Box>
+          <Text color="grey" fontSize="sm">
+            {format(new Date(createdAt), 'MMM dd yyyy')}
+          </Text>
+        </Box>
+        <Box mt={5}>
+          <ReactMarkdown source={content.substring(0, 120)} />
+        </Box>
+      </Box>
+    </Link>
+  );
+};
+
+Note.propTypes = {
+  note: instanceOf(Object).isRequired,
+};
+
+export default Note;

--- a/src/components/Router.js
+++ b/src/components/Router.js
@@ -3,13 +3,15 @@ import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
 
 import MyNotes from './Note/MyNotes';
 import Layout from './layout';
+import Note from './Note/Note';
 
 const AppRouter = () => (
   <>
     <Router>
       <Layout>
         <Switch>
-          <Route path="/my-notes" component={MyNotes} />
+          <Route exact path="/my-notes" component={MyNotes} />
+          <Route exact path="/note/:noteId" component={Note} />
         </Switch>
       </Layout>
     </Router>

--- a/src/components/core/Header.js
+++ b/src/components/core/Header.js
@@ -53,9 +53,12 @@ const Header = (props) => (
     padding="0.8rem"
     bg="gray.700"
     color="white"
+    top={0}
+    pos="sticky"
+    h={{ sm: '10vh', md: '6vh' }}
     {...props}
   >
-    <Flex align="center" mr={5} height="15px" justify="flex-start">
+    <Flex align="center" mr={5} justify="flex-start">
       <Image src={logo} alt="Notedly" />
     </Flex>
 

--- a/src/components/core/Home.js
+++ b/src/components/core/Home.js
@@ -3,18 +3,12 @@ import { useQuery } from '@apollo/client';
 
 import { NoteFeedQuery } from '../../graphql/queries/noteFeed';
 import NoteFeed from '../Note/NoteFeed';
-import Loader from './Loader';
+import { NotesLoader } from './Loader';
 
 const Home = () => {
   const { loading, error, data } = useQuery(NoteFeedQuery);
 
-  if (loading) {
-    return (
-      <Loader>
-        <NoteFeed />
-      </Loader>
-    );
-  }
+  if (loading) return <NotesLoader />;
 
   if (error) return <p style={{ textAlign: 'center' }}>....Error......</p>;
 

--- a/src/components/core/Loader.js
+++ b/src/components/core/Loader.js
@@ -1,11 +1,49 @@
 import React from 'react';
-import { instanceOf } from 'prop-types';
-import { Skeleton } from '@chakra-ui/core';
+import ContentLoader from 'react-content-loader';
 
-const Loader = ({ children }) => <Skeleton>{children}</Skeleton>;
+const UserLoader = (props) => (
+  <ContentLoader
+    viewBox="0 0 400 160"
+    height="100%"
+    width="100%"
+    speed={2}
+    {...props}
+  >
+    <rect x="110" y="21" rx="4" ry="4" width="254" height="6" />
+    <rect x="111" y="41" rx="3" ry="3" width="185" height="7" />
+    <rect x="304" y="-46" rx="3" ry="3" width="350" height="6" />
+    <rect x="371" y="-45" rx="3" ry="3" width="380" height="6" />
+    <rect x="484" y="-45" rx="3" ry="3" width="201" height="6" />
+    <circle cx="48" cy="48" r="48" />
+  </ContentLoader>
+);
 
-Loader.propTypes = {
-  children: instanceOf(Array).isRequired,
-};
+const NotesLoader = (props) => (
+  <ContentLoader
+    viewBox="0 0 500 475"
+    height="100%"
+    width="100%"
+    speed={2}
+    {...props}
+  >
+    <circle cx="70.2" cy="73.2" r="41.3" />
+    <rect x="129.9" y="29.5" width="125.5" height="17" />
+    <rect x="129.9" y="64.7" width="296" height="17" />
+    <rect x="129.9" y="97.8" width="253.5" height="17" />
+    <rect x="129.9" y="132.3" width="212.5" height="17" />
 
-export default Loader;
+    <circle cx="70.7" cy="243.5" r="41.3" />
+    <rect x="130.4" y="199.9" width="125.5" height="17" />
+    <rect x="130.4" y="235" width="296" height="17" />
+    <rect x="130.4" y="268.2" width="253.5" height="17" />
+    <rect x="130.4" y="302.6" width="212.5" height="17" />
+
+    <circle cx="70.7" cy="412.7" r="41.3" />
+    <rect x="130.4" y="369" width="125.5" height="17" />
+    <rect x="130.4" y="404.2" width="296" height="17" />
+    <rect x="130.4" y="437.3" width="253.5" height="17" />
+    <rect x="130.4" y="471.8" width="212.5" height="17" />
+  </ContentLoader>
+);
+
+export { UserLoader, NotesLoader };

--- a/src/components/layout/index.js
+++ b/src/components/layout/index.js
@@ -1,5 +1,4 @@
 import React from 'react';
-// import PropTypes from 'prop-types';
 import { useLocation } from 'react-router-dom';
 import { Grid, Flex } from '@chakra-ui/core';
 
@@ -8,34 +7,58 @@ import Header from '../core/Header';
 import Favorites from '../Note/Favorites';
 import Home from '../core/Home';
 import MyNotes from '../Note/MyNotes';
+import Note from '../Note/Note';
 
 const Layout = () => {
   const { pathname } = useLocation();
+  const noteId = pathname.split('/')[2];
+
+  React.useEffect(() => {
+    localStorage.setItem(
+      'jwt',
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJfaWQiOiI1ZWNhZTdkNjI1YWM5YzI5NWFhN2QxY2MiLCJpYXQiOjE1OTA1Mzc2NzIsImV4cCI6MTU5MDYyNDA3Mn0.ITtrgJ-LSaj-vpVWknb9i-lZo2lQj_n7sfSn6qaAqcQ',
+    );
+  }, []);
+
+  const renderRoute = () => {
+    switch (pathname) {
+      case '/my-notes':
+        return <MyNotes />;
+      case `/note/${noteId}`:
+        return <Note />;
+      default:
+        return <Home />;
+    }
+  };
+
   return (
     <>
       <Header />
-      <Grid
-        templateColumns="repeat(auto-fit, minmax(100px, 1fr))"
-        columnGap={4}
-        w="100%"
-      >
-        <Flex bg="blue.900" align="baseline" justify="center">
+      <Grid templateColumns="repeat(3, 1fr)" columnGap={4} w="100vw">
+        <Flex
+          bg="blue.900"
+          align="baseline"
+          justify="center"
+          h="94vh"
+          overflow="scroll"
+        >
           <Authors />
         </Flex>
-        <Flex bg="blue.500" align="baseline" justify="center">
-          {pathname === '/my-notes' ? <MyNotes /> : <Home />}
+        <Flex align="baseline" justify="center" h="94vh" overflow="scroll">
+          {renderRoute()}
         </Flex>
-        <Flex bg="blue.100" align="baseline" justify="center">
+        <Flex
+          bg="blue.100"
+          align="baseline"
+          justify="center"
+          h="94vh"
+          overflow="scroll"
+        >
           <Favorites />
         </Flex>
       </Grid>
     </>
   );
 };
-
-// Layout.propTypes = {
-//   children: PropTypes.oneOfType([PropTypes.object, PropTypes.symbol])
-//     .isRequired,
-// };
 
 export default Layout;

--- a/src/graphql/index.js
+++ b/src/graphql/index.js
@@ -1,10 +1,45 @@
-import { ApolloClient, InMemoryCache } from '@apollo/client';
+import {
+  ApolloClient,
+  InMemoryCache,
+  createHttpLink,
+  ApolloLink,
+} from '@apollo/client';
+import { onError } from 'apollo-link-error';
 
 const uri = process.env.API_URL;
 const cache = new InMemoryCache();
+const httpLink = createHttpLink({ uri });
+
+const authHeaderMiddlewareLink = new ApolloLink((operation, forward) => {
+  operation.setContext((prevContext) => ({
+    ...prevContext,
+    headers: {
+      ...prevContext.headers,
+      Authorization: localStorage.getItem('jwt')
+        ? `Bearer ${localStorage.getItem('jwt')}`
+        : null,
+    },
+  }));
+
+  return forward(operation);
+});
 
 export const client = new ApolloClient({
-  uri,
+  link: ApolloLink.from([
+    authHeaderMiddlewareLink,
+    onError(({ graphQLErrors }) => {
+      if (graphQLErrors) {
+        graphQLErrors.map(({ extensions }) => {
+          if (extensions.code === 'UNAUTHENTICATED') {
+            localStorage.removeItem('jwt');
+            client.clearStore();
+          }
+        });
+      }
+    }),
+    httpLink,
+  ]),
   cache,
   connectToDevTools: true,
+  resolvers: {},
 });

--- a/src/graphql/queries/note.js
+++ b/src/graphql/queries/note.js
@@ -1,0 +1,21 @@
+import { gql } from '@apollo/client';
+
+export const NoteByIdQuery = gql`
+  query Note($id: ID!) {
+    note(id: $id) {
+      id
+      content
+      author {
+        id
+        username
+        avatar
+      }
+      favoritedBy {
+        username
+      }
+      favoriteCount
+      createdAt
+      updatedAt
+    }
+  }
+`;

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1,7 +1,8 @@
 body {
   margin: 0;
   padding: 0;
-  width: 100%;
+  width: 100vw;
+  height: 100vh;
   background-color: #ffffff;
   color: #000000;
   -webkit-background-size: cover;
@@ -13,9 +14,18 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  overflow-y: scroll;
+  scrollbar-width: none; /* Firefox */
+  -ms-overflow-style: none;
 }
 
 code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
+}
+
+::-webkit-scrollbar {
+  /* WebKit */
+  width: 0;
+  height: 0;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2108,6 +2108,24 @@ apollo-link-context@^1.0.20:
     apollo-link "^1.2.14"
     tslib "^1.9.3"
 
+apollo-link-error@^1.1.13:
+  version "1.1.13"
+  resolved "https://registry.yarnpkg.com/apollo-link-error/-/apollo-link-error-1.1.13.tgz#c1a1bb876ffe380802c8df0506a32c33aad284cd"
+  integrity sha512-jAZOOahJU6bwSqb2ZyskEK1XdgUY9nkmeclCrW7Gddh1uasHVqmoYc4CKdb0/H0Y1J9lvaXKle2Wsw/Zx1AyUg==
+  dependencies:
+    apollo-link "^1.2.14"
+    apollo-link-http-common "^0.2.16"
+    tslib "^1.9.3"
+
+apollo-link-http-common@^0.2.16:
+  version "0.2.16"
+  resolved "https://registry.yarnpkg.com/apollo-link-http-common/-/apollo-link-http-common-0.2.16.tgz#756749dafc732792c8ca0923f9a40564b7c59ecc"
+  integrity sha512-2tIhOIrnaF4UbQHf7kjeQA/EmSorB7+HyJIIrUjJOKBgnXwuexi8aMecRlqTIDWcyVXCeqLhUnztMa6bOH/jTg==
+  dependencies:
+    apollo-link "^1.2.14"
+    ts-invariant "^0.4.0"
+    tslib "^1.9.3"
+
 apollo-link@^1.2.14:
   version "1.2.14"
   resolved "https://registry.yarnpkg.com/apollo-link/-/apollo-link-1.2.14.tgz#3feda4b47f9ebba7f4160bef8b977ba725b684d9"
@@ -6619,6 +6637,11 @@ react-clientside-effect@^1.2.2:
   integrity sha512-nRmoyxeok5PBO6ytPvSjKp9xwXg9xagoTK1mMjwnQxqM9Hd7MNPl+LS1bOSOe+CV2+4fnEquc7H/S8QD3q697A==
   dependencies:
     "@babel/runtime" "^7.0.0"
+
+react-content-loader@^5.0.4:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/react-content-loader/-/react-content-loader-5.0.4.tgz#1493491d2f6b309d281d84144a655417ea734486"
+  integrity sha512-hxv4Td1kQxFOmIUbBZ2S3HGZ/jJr28aJvM+8fndm9TmNOE7tSde7WSTL6R68aTS6qE0BA3ptcWIErrP704pQSw==
 
 react-dom@^16.13.1:
   version "16.13.1"


### PR DESCRIPTION
#### What does this PR do

- adds loader components to the project

#### Tasks that support this implementation

- install and setup loader components
- `intergrate` loader components into the Note and NoteFeed components
- setup client request authentication using `apollo-link`
- add SampleNote component to display noteFeeds

#### Changes made to the existing code if any

#### Tests recorded for this feature / fix

- [ ] unit tests
- [ ] e2e tests

#### Steps to manually test this implementation

##### Development Environment setup

- clone the repository and run `cd notedly-client` to change to the project directory
- run `yarn install` command to install all the necessary dependencies
- run `yarn run start` command to start the development server

##### Test Environment setup