### PR TITLE
chore: add dynamic url mapping based on the NODE_ENV variable

### DIFF
--- a/src/components/layout/index.js
+++ b/src/components/layout/index.js
@@ -18,7 +18,7 @@ const Layout = () => {
   React.useEffect(() => {
     localStorage.setItem(
       'jwt',
-      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJfaWQiOiI1ZWNlZjExMTMwOTljZTE5NjBhMDA2MTIiLCJpYXQiOjE1OTE0MzgyMzIsImV4cCI6MTU5MTUyNDYzMn0.OQIuJx9tlY2tvcTOPgshuIIYoC55RGVZEpyNBddabHY',
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJfaWQiOiI1ZWNlZjExMTMwOTljZTE5NjBhMDA2MTIiLCJpYXQiOjE1OTE1Mjg2NDIsImV4cCI6MTU5MTYxNTA0Mn0.9TH2RPeURV0jjLTiOokUwtcwmtHro1PBnwCZ6YsMqhs',
     );
   }, []);
 

--- a/src/graphql/index.js
+++ b/src/graphql/index.js
@@ -6,7 +6,9 @@ import {
 } from '@apollo/client';
 import { onError } from 'apollo-link-error';
 
-const uri = process.env.API_URL;
+const uri = process.env.NODE_ENV === 'production'
+  ? process.env.API_PROD_URL
+  : process.env.API_DEV_URL;
 const cache = new InMemoryCache();
 const httpLink = createHttpLink({ uri });
 


### PR DESCRIPTION
#### What does this PR do

- adds dynamic url mapping to the graphQL client based on the NODE_ENV variable

#### Tasks that support this implementation

- adds dynamic url mapping to the graphQL client based on the NODE_ENV variable

#### Tests recorded for this feature / fix

- [ ] unit tests
- [ ] e2e tests

#### Steps to manually test this implementation

##### Development Environment setup

- clone the repository and run `cd notedly-client` to change to the project directory
- run `yarn install` command to install all the necessary dependencies
- run `yarn run start` command to start the development server